### PR TITLE
Pixelcount incrementation and gowinsyn synthesis

### DIFF
--- a/example_lcd/lcd_pjt/impl/project_process_config.json
+++ b/example_lcd/lcd_pjt/impl/project_process_config.json
@@ -55,7 +55,7 @@
  "SSPI" : true,
  "Show_All_Warnings" : false,
  "Synthesis On/Off Implemented as Translate On/Off" : false,
- "Synthesize_tool" : "Synplify",
+ "Synthesize_tool" : "GowinSyn",
  "TopModule" : "TOP",
  "USERCODE_CUSTOM" : false,
  "USERCODE_CUSTOM_TEXT" : "00000000",

--- a/example_lcd/lcd_pjt/src/VGAMod.v
+++ b/example_lcd/lcd_pjt/src/VGAMod.v
@@ -54,6 +54,8 @@ module VGAMod
             LineCount       <=  16'b0;
             PixelCount      <=  16'b0;
             end
+        else
+            PixelCount      <=  PixelCount + 1'b1;
     end
 
 	reg			[9:0]  Data_R;


### PR DESCRIPTION
Some LCD project fixes :
- Increment PixelCount as shuichitakano [comment](https://github.com/sipeed/Tang-Nano-examples/issues/1)
- use gowinSyn to avoid Synplify licence problem